### PR TITLE
Update InitialiseSettings.php

### DIFF
--- a/wmf-config/InitialiseSettings.php
+++ b/wmf-config/InitialiseSettings.php
@@ -6867,7 +6867,7 @@ $wgConf->settings = array(
 		'filemover' => array( 'movefile' => true ),
 		'OTRS-member' => array( 'autopatrol' => true ),
 		'Image-reviewer' => array( 'autopatrol' => true, 'upload_by_url' => true ),
-		'sysop' => array( 'upload_by_url' => true ),
+		'sysop' => array( 'upload_by_url' => true, 'translate-manage' => true, 'translate-import' => true, 'pagetranslation' => true ), // Bug 49173
 	),
 	'dawiki' => array(
 		'patroller'		=> array( 'patrol' => true, 'autopatrol' => true, 'rollback' => true, ),


### PR DESCRIPTION
Adding translationadmin rights
('translate-manage' => true, 'translate-import' => true, 'pagetranslation' => true)
to commonswiki sysop group per Bug 49173 and https://commons.wikimedia.org/w/index.php?title=Commons:Village_pump&oldid=97614612#Allow_admins_to_assign_this_right
