### PR TITLE
link Grafana in addition to Ganglia

### DIFF
--- a/docroot/noc/index.html
+++ b/docroot/noc/index.html
@@ -27,7 +27,7 @@
 		   <dd>Core DB Replication Layout and Lag</dd>
 		   <dt><a href="./db.php">DB clusters</a></dt>
 		   <dd>Database cluster info</dd>
-		<dt><a href="https://ganglia.wikimedia.org/">Ganglia</a></dt>
+		<dt><a href="https://grafana.wikimedia.org/">Grafana</a> (new) or <a href="https://ganglia.wikimedia.org/">Ganglia</a> (old)</dt>
 		   <dd>Server utilization</dd>
 		<dt><a href="https://phabricator.wikimedia.org/">Phabricator</a></dt>
 		   <dd>Bug tracker</dd>


### PR DESCRIPTION
I left Ganglia in, just so that people can still find that if they find some utility in it, but can also go directly to grafana.